### PR TITLE
feat(notes): long-acting insulin notes (type) + injection-time prefer…

### DIFF
--- a/src/main/java/che/glucosemonitorbe/dto/CreateNoteRequest.java
+++ b/src/main/java/che/glucosemonitorbe/dto/CreateNoteRequest.java
@@ -23,6 +23,8 @@ public class CreateNoteRequest {
     private String insulinDose;
     private Boolean mockData;
     private String absorptionMode;
+    /** Note category: "normal" (default) or "long_acting". */
+    private String type;
 
     /**
      * Pre-computed nutrition profile JSON from the iOS Nutrition analyser.
@@ -130,5 +132,13 @@ public class CreateNoteRequest {
 
     public void setNutritionProfile(String nutritionProfile) {
         this.nutritionProfile = nutritionProfile;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
     }
 }

--- a/src/main/java/che/glucosemonitorbe/dto/NoteDto.java
+++ b/src/main/java/che/glucosemonitorbe/dto/NoteDto.java
@@ -25,6 +25,8 @@ public class NoteDto {
     private String insulinDose;
     private String nutritionProfile;
     private String absorptionMode;
+    /** Note category: "normal" (default) or "long_acting". */
+    private String type;
     private boolean mockData;
     
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
@@ -149,7 +151,15 @@ public class NoteDto {
     public void setAbsorptionMode(String absorptionMode) {
         this.absorptionMode = absorptionMode;
     }
-    
+
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
     public LocalDateTime getCreatedAt() {
         return createdAt;
     }

--- a/src/main/java/che/glucosemonitorbe/dto/UpdateNoteRequest.java
+++ b/src/main/java/che/glucosemonitorbe/dto/UpdateNoteRequest.java
@@ -20,6 +20,8 @@ public class UpdateNoteRequest {
     private String insulinDose;
     private Boolean mockData;
     private String absorptionMode;
+    /** Note category: "normal" or "long_acting". Null leaves the existing value unchanged. */
+    private String type;
 
     // Constructors
     public UpdateNoteRequest() {}
@@ -103,5 +105,13 @@ public class UpdateNoteRequest {
 
     public void setAbsorptionMode(String absorptionMode) {
         this.absorptionMode = absorptionMode;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
     }
 }

--- a/src/main/java/che/glucosemonitorbe/dto/UpdateUserInsulinPreferencesRequest.java
+++ b/src/main/java/che/glucosemonitorbe/dto/UpdateUserInsulinPreferencesRequest.java
@@ -11,4 +11,10 @@ public class UpdateUserInsulinPreferencesRequest {
 
     @NotBlank
     private String longActingInsulinCode;
+
+    /**
+     * Optional daily long-acting injection time as "HH:mm". When null the existing value is left
+     * unchanged; an empty string clears it. Used by the client to gate the logging action.
+     */
+    private String longActingInjectionTime;
 }

--- a/src/main/java/che/glucosemonitorbe/dto/UserInsulinPreferencesDTO.java
+++ b/src/main/java/che/glucosemonitorbe/dto/UserInsulinPreferencesDTO.java
@@ -14,4 +14,6 @@ public class UserInsulinPreferencesDTO {
     private String longActingInsulinCode;
     private InsulinCatalogDTO rapidInsulin;
     private InsulinCatalogDTO longActingInsulin;
+    /** Optional daily long-acting injection time as "HH:mm" (null when unset). */
+    private String longActingInjectionTime;
 }

--- a/src/main/java/che/glucosemonitorbe/entity/Note.java
+++ b/src/main/java/che/glucosemonitorbe/entity/Note.java
@@ -12,7 +12,12 @@ import java.util.UUID;
 @Entity
 @Table(name = "notes")
 public class Note {
-    
+
+    /** {@link #type} value for ordinary meal/correction/bolus notes (the default). */
+    public static final String TYPE_NORMAL = "normal";
+    /** {@link #type} value for long-acting (basal) insulin notes — excluded from bolus IOB/predictions. */
+    public static final String TYPE_LONG_ACTING = "long_acting";
+
     @Id
     @GeneratedValue(strategy = GenerationType.UUID)
     private UUID id;
@@ -51,6 +56,10 @@ public class Note {
 
     @Column(name = "absorption_mode", length = 32)
     private String absorptionMode;
+
+    /** Note category: {@link #TYPE_NORMAL} (default) or {@link #TYPE_LONG_ACTING}. */
+    @Column(name = "type", nullable = false, length = 20)
+    private String type = TYPE_NORMAL;
 
     @Column(name = "mock_data", nullable = false)
     private boolean mockData = false;
@@ -182,6 +191,19 @@ public class Note {
 
     public void setAbsorptionMode(String absorptionMode) {
         this.absorptionMode = absorptionMode;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    /** True when this note is a long-acting (basal) injection — excluded from bolus IOB/predictions. */
+    public boolean isLongActing() {
+        return TYPE_LONG_ACTING.equals(type);
     }
 
     public boolean isMockData() {

--- a/src/main/java/che/glucosemonitorbe/entity/UserInsulinPreferences.java
+++ b/src/main/java/che/glucosemonitorbe/entity/UserInsulinPreferences.java
@@ -18,6 +18,7 @@ import org.hibernate.annotations.UpdateTimestamp;
 import org.hibernate.annotations.UuidGenerator;
 
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.UUID;
 
 @Getter
@@ -45,6 +46,10 @@ public class UserInsulinPreferences {
     @ManyToOne(fetch = FetchType.EAGER, optional = false)
     @JoinColumn(name = "long_acting_insulin_id", referencedColumnName = "id", nullable = false)
     private InsulinCatalog longActingInsulin;
+
+    /** Optional daily time the user takes their long-acting (basal) dose; gates the logging action. */
+    @Column(name = "long_acting_injection_time")
+    private LocalTime longActingInjectionTime;
 
     @CreationTimestamp
     @Column(name = "created_at", nullable = false, updatable = false)

--- a/src/main/java/che/glucosemonitorbe/mapper/NoteMapper.java
+++ b/src/main/java/che/glucosemonitorbe/mapper/NoteMapper.java
@@ -28,6 +28,7 @@ public class NoteMapper {
         dto.setInsulinDose(note.getInsulinDose());
         dto.setNutritionProfile(note.getNutritionProfile());
         dto.setAbsorptionMode(note.getAbsorptionMode());
+        dto.setType(note.getType());
         dto.setMockData(note.isMockData());
         dto.setCreatedAt(note.getCreatedAt());
         dto.setUpdatedAt(note.getUpdatedAt());
@@ -56,8 +57,11 @@ public class NoteMapper {
         note.setInsulinDose(dto.getInsulinDose());
         note.setNutritionProfile(dto.getNutritionProfile());
         note.setAbsorptionMode(dto.getAbsorptionMode());
+        if (dto.getType() != null) {
+            note.setType(dto.getType());
+        }
         note.setMockData(dto.isMockData());
-        
+
         return note;
     }
     
@@ -98,6 +102,9 @@ public class NoteMapper {
         }
         if (dto.getAbsorptionMode() != null) {
             existingNote.setAbsorptionMode(dto.getAbsorptionMode());
+        }
+        if (dto.getType() != null) {
+            existingNote.setType(dto.getType());
         }
         existingNote.setMockData(dto.isMockData());
     }

--- a/src/main/java/che/glucosemonitorbe/service/GlucoseCalculationsService.java
+++ b/src/main/java/che/glucosemonitorbe/service/GlucoseCalculationsService.java
@@ -82,7 +82,8 @@ public class GlucoseCalculationsService {
                 .map(this::convertNoteToCarbsEntry)
                 .toList());
         List<InsulinDose> insulinEntries = new ArrayList<>(recentNotes.stream()
-                .filter(note -> note.getInsulin() != null && note.getInsulin() > 0)
+                // Long-acting (basal) doses are not rapid-acting boluses — exclude from bolus IOB & predictions.
+                .filter(note -> note.getInsulin() != null && note.getInsulin() > 0 && !note.isLongActing())
                 .map(this::convertNoteToInsulinDose)
                 .toList());
 
@@ -365,7 +366,7 @@ public class GlucoseCalculationsService {
             }
 
             Note bolus = sorted.stream()
-                    .filter(n -> n.getInsulin() != null && n.getInsulin() > 0)
+                    .filter(n -> n.getInsulin() != null && n.getInsulin() > 0 && !n.isLongActing())
                     .filter(n -> n.getTimestamp().isBefore(meal.getTimestamp()) || n.getTimestamp().isEqual(meal.getTimestamp()))
                     .filter(n -> {
                         long minutes = java.time.Duration.between(n.getTimestamp(), meal.getTimestamp()).toMinutes();

--- a/src/main/java/che/glucosemonitorbe/service/NotesService.java
+++ b/src/main/java/che/glucosemonitorbe/service/NotesService.java
@@ -81,6 +81,7 @@ public class NotesService {
             request.getDetailedInput(),
             request.getInsulinDose()
         );
+        note.setType(request.getType() != null ? request.getType() : Note.TYPE_NORMAL);
         note.setMockData(Boolean.TRUE.equals(request.getMockData()));
         if (request.getAbsorptionMode() != null) {
             note.setAbsorptionMode(request.getAbsorptionMode());
@@ -110,8 +111,9 @@ public class NotesService {
 
         // Fire over-injection check asynchronously — does not block the response.
         // Condition: note has insulin AND we have a current glucose reading to anchor the prediction.
+        // Long-acting (basal) doses are not boluses, so they never trigger the over-injection alert.
         double insulinUnits = savedNote.getInsulin() != null ? savedNote.getInsulin() : 0.0;
-        if (insulinUnits > 0) {
+        if (insulinUnits > 0 && !savedNote.isLongActing()) {
             // Resolve the username from the userId for the calculations service
             try {
                 String username = userService.getUserById(userId).getUsername();

--- a/src/main/java/che/glucosemonitorbe/service/UserInsulinPreferencesService.java
+++ b/src/main/java/che/glucosemonitorbe/service/UserInsulinPreferencesService.java
@@ -10,6 +10,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
 import java.util.UUID;
 
 @Service
@@ -18,6 +20,9 @@ public class UserInsulinPreferencesService {
 
     public static final String DEFAULT_RAPID_CODE = "FIASP";
     public static final String DEFAULT_LONG_ACTING_CODE = "TRESIBA";
+
+    /** Wire format for the long-acting injection time ("HH:mm", 24-hour). */
+    private static final DateTimeFormatter INJECTION_TIME_FORMAT = DateTimeFormatter.ofPattern("HH:mm");
 
     private final UserInsulinPreferencesRepository userInsulinPreferencesRepository;
     private final InsulinCatalogService insulinCatalogService;
@@ -75,9 +80,28 @@ public class UserInsulinPreferencesService {
         entity.setUserId(userId);
         entity.setRapidInsulin(rapid);
         entity.setLongActingInsulin(basal);
+        // null → leave unchanged; "" → clear; "HH:mm" → set. Lets older clients omit the field safely.
+        if (request.getLongActingInjectionTime() != null) {
+            entity.setLongActingInjectionTime(parseInjectionTime(request.getLongActingInjectionTime()));
+        }
 
         UserInsulinPreferences saved = userInsulinPreferencesRepository.save(entity);
         return toDto(saved);
+    }
+
+    private static LocalTime parseInjectionTime(String raw) {
+        if (raw == null || raw.isBlank()) {
+            return null;
+        }
+        try {
+            return LocalTime.parse(raw.trim(), INJECTION_TIME_FORMAT);
+        } catch (Exception e) {
+            throw new IllegalArgumentException("Invalid long-acting injection time (expected HH:mm): " + raw);
+        }
+    }
+
+    private static String formatInjectionTime(LocalTime time) {
+        return time != null ? time.format(INJECTION_TIME_FORMAT) : null;
     }
 
     private UserInsulinPreferencesDTO buildDtoWithCatalogOnly(String rapidCode, String longCode) {
@@ -97,6 +121,7 @@ public class UserInsulinPreferencesService {
                 .longActingInsulinCode(p.getLongActingInsulin().getCode())
                 .rapidInsulin(InsulinCatalogService.toDto(p.getRapidInsulin()))
                 .longActingInsulin(InsulinCatalogService.toDto(p.getLongActingInsulin()))
+                .longActingInjectionTime(formatInjectionTime(p.getLongActingInjectionTime()))
                 .build();
     }
 }

--- a/src/main/resources/db/migration/V24__add_note_type.sql
+++ b/src/main/resources/db/migration/V24__add_note_type.sql
@@ -1,0 +1,8 @@
+-- Note category discriminator. Long-acting (basal) insulin notes are tagged 'long_acting'
+-- so their dose (stored in the existing `insulin` column) can be excluded from rapid-acting
+-- (bolus) IOB, prediction, bolus-to-meal timing, and over-injection math. Existing rows are
+-- ordinary meal/correction/bolus notes → 'normal'.
+ALTER TABLE notes ADD COLUMN type VARCHAR(20) NOT NULL DEFAULT 'normal';
+
+-- Speeds up the common "recent notes by user" scans that now also branch on type.
+CREATE INDEX IF NOT EXISTS idx_notes_user_type ON notes (user_id, type);

--- a/src/main/resources/db/migration/V25__add_long_acting_injection_time.sql
+++ b/src/main/resources/db/migration/V25__add_long_acting_injection_time.sql
@@ -1,0 +1,4 @@
+-- Optional daily time-of-day at which the user takes their long-acting (basal) insulin.
+-- Used by the client to enable the "Log long-acting insulin" action only around that time.
+-- Nullable: when unset, the client leaves the action always available.
+ALTER TABLE user_insulin_preferences ADD COLUMN long_acting_injection_time TIME;

--- a/src/test/java/che/glucosemonitorbe/service/GlucoseCalculationsServiceTest.java
+++ b/src/test/java/che/glucosemonitorbe/service/GlucoseCalculationsServiceTest.java
@@ -2,6 +2,7 @@ package che.glucosemonitorbe.service;
 
 import che.glucosemonitorbe.config.FeatureToggleConfig;
 import che.glucosemonitorbe.domain.CarbsEntry;
+import che.glucosemonitorbe.domain.InsulinDose;
 import che.glucosemonitorbe.dto.COBSettingsDTO;
 import che.glucosemonitorbe.dto.GlucoseCalculationsRequest;
 import che.glucosemonitorbe.dto.PredictionFactors;
@@ -202,6 +203,53 @@ class GlucoseCalculationsServiceTest {
                 .as("HFHP note from 7.5 hours ago must be included in COB calculation; "
                         + "current 6-hour window excludes it (BUG: L2)")
                 .anyMatch(e -> e.getCarbs() != null && e.getCarbs() >= 60.0);
+    }
+
+    // ── Long-acting (basal) doses must not be treated as bolus IOB ───────────
+
+    /**
+     * A long-acting (basal) note carries an insulin dose but must NEVER be fed into the
+     * rapid-acting bolus IOB curve / prediction path. It is excluded from the insulinEntries
+     * passed to InsulinCalculatorService. Regression guard for the long-acting logging feature.
+     */
+    @Test
+    void longActingNote_excludedFromBolusInsulinEntries() {
+        String username = "basal_user";
+        UUID userId = UUID.randomUUID();
+        when(userService.getUserByUsername(username))
+                .thenReturn(UserDto.builder().id(userId).username(username).build());
+
+        COBSettingsDTO cobSettings = new COBSettingsDTO();
+        cobSettings.setUserId(userId);
+        cobSettings.setCarbRatio(2.0);
+        cobSettings.setIsf(1.0);
+        cobSettings.setCarbHalfLife(45);
+        cobSettings.setMaxCOBDuration(240);
+        when(cOBSettingsService.getCOBSettings(userId)).thenReturn(cobSettings);
+
+        // 20 U of long-acting taken 1 h ago — a massive phantom bolus IOB if mis-classified.
+        Note basal = new Note(userId, LocalDateTime.now().minusHours(1), 0.0, 20.0, "Tresiba");
+        basal.setId(UUID.randomUUID());
+        basal.setType(Note.TYPE_LONG_ACTING);
+        when(noteRepository.findByUserIdAndTimestampBetween(any(), any(), any()))
+                .thenReturn(List.of(basal));
+
+        when(cobService.calculateTotalCarbsOnBoard(any(), any(), any(COBSettingsDTO.class))).thenReturn(0.0);
+        when(userInsulinPreferencesService.getRapidIobParameters(userId))
+                .thenReturn(new RapidInsulinIobParameters(4.0, 75.0));
+        when(featureToggleConfig.isNutritionAwarePredictionEnabled()).thenReturn(false);
+
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<List<InsulinDose>> insulinCaptor = ArgumentCaptor.forClass(List.class);
+        when(insulinCalculatorService.calculateTotalActiveInsulin(
+                insulinCaptor.capture(), any(), anyDouble(), anyDouble())).thenReturn(0.0);
+
+        service.calculateGlucoseData(GlucoseCalculationsRequest.builder()
+                .currentGlucose(6.0).userId(username).includePredictionFactors(false).build());
+
+        assertThat(insulinCaptor.getValue())
+                .as("long-acting (basal) doses must be excluded from bolus IOB entries")
+                .isEmpty();
     }
 
     // ── P4: getCOBSettings called O(N) times per prediction path ─────────────

--- a/src/test/java/che/glucosemonitorbe/service/UserInsulinPreferencesServiceTest.java
+++ b/src/test/java/che/glucosemonitorbe/service/UserInsulinPreferencesServiceTest.java
@@ -7,10 +7,12 @@ import che.glucosemonitorbe.entity.UserInsulinPreferences;
 import che.glucosemonitorbe.repository.UserInsulinPreferencesRepository;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.time.LocalTime;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -87,6 +89,42 @@ class UserInsulinPreferencesServiceTest {
 
         assertEquals("FIASP", result.getRapidInsulinCode());
         assertEquals("TRESIBA", result.getLongActingInsulinCode());
+    }
+
+    @Test
+    void savePreferencesPersistsAndReturnsInjectionTime() {
+        UUID userId = UUID.randomUUID();
+        UpdateUserInsulinPreferencesRequest request = new UpdateUserInsulinPreferencesRequest();
+        request.setRapidInsulinCode("FIASP");
+        request.setLongActingInsulinCode("TRESIBA");
+        request.setLongActingInjectionTime("22:00");
+
+        when(insulinCatalogService.getRequiredByCode("FIASP")).thenReturn(insulin("FIASP", InsulinCatalog.Category.RAPID));
+        when(insulinCatalogService.getRequiredByCode("TRESIBA")).thenReturn(insulin("TRESIBA", InsulinCatalog.Category.LONG_ACTING));
+        when(userInsulinPreferencesRepository.findByUserId(userId)).thenReturn(Optional.empty());
+
+        ArgumentCaptor<UserInsulinPreferences> captor = ArgumentCaptor.forClass(UserInsulinPreferences.class);
+        // Return the entity as-saved so the DTO reflects the parsed time.
+        when(userInsulinPreferencesRepository.save(captor.capture())).thenAnswer(inv -> inv.getArgument(0));
+
+        UserInsulinPreferencesDTO result = service.savePreferences(userId, request);
+
+        assertEquals(LocalTime.of(22, 0), captor.getValue().getLongActingInjectionTime());
+        assertEquals("22:00", result.getLongActingInjectionTime());
+    }
+
+    @Test
+    void savePreferencesRejectsInvalidInjectionTime() {
+        UUID userId = UUID.randomUUID();
+        UpdateUserInsulinPreferencesRequest request = new UpdateUserInsulinPreferencesRequest();
+        request.setRapidInsulinCode("FIASP");
+        request.setLongActingInsulinCode("TRESIBA");
+        request.setLongActingInjectionTime("9pm"); // not HH:mm
+
+        when(insulinCatalogService.getRequiredByCode("FIASP")).thenReturn(insulin("FIASP", InsulinCatalog.Category.RAPID));
+        when(insulinCatalogService.getRequiredByCode("TRESIBA")).thenReturn(insulin("TRESIBA", InsulinCatalog.Category.LONG_ACTING));
+
+        assertThrows(IllegalArgumentException.class, () -> service.savePreferences(userId, request));
     }
 
     private static InsulinCatalog insulin(String code, InsulinCatalog.Category category) {


### PR DESCRIPTION
…ence

Backend support for logging long-acting (basal) insulin as a note, kept out of all rapid-acting (bolus) math.

Notes:
- New 'type' column (V24): 'normal' (default, backfilled) or 'long_acting'.
- Long-acting notes carry their dose in the existing 'insulin' field but are excluded from: bolus IOB & the prediction path (GlucoseCalculationsService insulinEntries), bolus-to-meal timing, and the over-injection alert. Carbs math is unaffected (long-acting carbs are 0). Added to Note/DTOs/mapper.

Preferences:
- New nullable 'long_acting_injection_time' TIME column (V25) on user_insulin_preferences, exposed as an 'HH:mm' string in the prefs DTO and accepted (optional) on update. The client uses it to gate the logging action; null leaves it unset/unchanged. The long-acting insulin *name* was already configurable via the existing catalog preference.

Tests: long-acting note excluded from bolus insulin entries; injection-time round-trip + invalid-format rejection. Full suite green (V24/V25 migrations apply cleanly under Testcontainers).