### PR TITLE
feat(libre): on-demand sync endpoint with per-user concurrency control

### DIFF
--- a/src/main/java/che/glucosemonitorbe/controller/LibreLinkUpController.java
+++ b/src/main/java/che/glucosemonitorbe/controller/LibreLinkUpController.java
@@ -7,6 +7,7 @@ import che.glucosemonitorbe.dto.LibreGlucoseData;
 import che.glucosemonitorbe.dto.LibreGlucoseReading;
 import che.glucosemonitorbe.dto.LibreSensorInfo;
 import che.glucosemonitorbe.service.LibreLinkUpService;
+import che.glucosemonitorbe.service.LibreLinkUpSyncService;
 import che.glucosemonitorbe.service.UserDataSourceConfigService;
 import che.glucosemonitorbe.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -16,6 +17,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
@@ -33,6 +35,7 @@ public class LibreLinkUpController {
     private static final Logger logger = LoggerFactory.getLogger(LibreLinkUpController.class);
 
     private final LibreLinkUpService libreLinkUpService;
+    private final LibreLinkUpSyncService libreLinkUpSyncService;
     private final UserService userService;
     private final UserDataSourceConfigService dataSourceConfigService;
 
@@ -127,6 +130,39 @@ public class LibreLinkUpController {
                         patientId, authentication.getName(), e.getMessage());
             return ResponseEntity.badRequest().body("Failed to fetch glucose data: " + e.getMessage());
         }
+    }
+
+    /**
+     * On-demand LibreLinkUp sync for the authenticated user. Fetches the latest CGM readings
+     * immediately and stores them in the chart cache, bypassing the periodic scheduler interval so
+     * the iOS refresh button does not have to wait for the next tick.
+     *
+     * <p>Concurrency-safe via {@link LibreLinkUpSyncService}: per-user locking serialises a user's
+     * syncs (manual + scheduled), different users run in parallel, and rapid repeat taps are
+     * coalesced.
+     */
+    @Operation(summary = "Refresh LibreLinkUp readings now (on-demand sync)")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Sync completed (new or unchanged data)"),
+            @ApiResponse(responseCode = "202", description = "A sync for this user is already in progress"),
+            @ApiResponse(responseCode = "409", description = "No LibreLinkUp credentials configured"),
+            @ApiResponse(responseCode = "502", description = "Sync failed (auth/network error)")
+    })
+    @PostMapping("/sync-now")
+    public ResponseEntity<?> syncNow(Authentication authentication) {
+        UUID uid = userId(authentication);
+        logger.info("User {} requested on-demand LibreLinkUp sync", authentication.getName());
+
+        LibreLinkUpSyncService.Outcome outcome = libreLinkUpSyncService.syncUser(uid, true);
+        logger.info("On-demand LibreLinkUp sync for user {} -> {}", authentication.getName(), outcome);
+
+        HttpStatus status = switch (outcome) {
+            case NEW_DATA, NO_CHANGE, SKIPPED_BACKOFF -> HttpStatus.OK;
+            case IN_PROGRESS                          -> HttpStatus.ACCEPTED;
+            case SKIPPED_NO_CREDS                     -> HttpStatus.CONFLICT;
+            case ERROR                                -> HttpStatus.BAD_GATEWAY;
+        };
+        return ResponseEntity.status(status).body(java.util.Map.of("outcome", outcome.name()));
     }
 
     /**

--- a/src/main/java/che/glucosemonitorbe/scheduler/LibreLinkUpGlucoseSyncScheduler.java
+++ b/src/main/java/che/glucosemonitorbe/scheduler/LibreLinkUpGlucoseSyncScheduler.java
@@ -1,27 +1,20 @@
 package che.glucosemonitorbe.scheduler;
 
 import che.glucosemonitorbe.domain.UserDataSourceConfig;
-import che.glucosemonitorbe.domain.UserGlucoseSyncState;
-import che.glucosemonitorbe.dto.LibreAuthRequest;
-import che.glucosemonitorbe.dto.NightscoutEntryDto;
 import che.glucosemonitorbe.repository.UserDataSourceConfigRepository;
-import che.glucosemonitorbe.service.LibreLinkUpService;
-import che.glucosemonitorbe.service.NightscoutChartDataService;
-import che.glucosemonitorbe.service.UserGlucoseSyncStateService;
+import che.glucosemonitorbe.service.LibreLinkUpSyncService;
+import che.glucosemonitorbe.service.LibreLinkUpSyncService.Outcome;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
 import jakarta.annotation.PreDestroy;
 
-import java.time.Instant;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.OptionalLong;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
@@ -30,13 +23,13 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 /**
- * Periodically fetches CGM readings from LibreLinkUp for each user with an active LIBRE_LINK_UP
- * configuration and stores them in {@code nightscout_chart_data} (reusing the same table/service
- * as the Nightscout scheduler so the iOS chart endpoint works for both data sources).
+ * Periodically triggers a LibreLinkUp sync for every user with an active LIBRE_LINK_UP
+ * configuration. The actual per-user fetch+store (and all concurrency control) lives in
+ * {@link LibreLinkUpSyncService}; this class only fans out across users and aggregates the result.
  *
- * <p>The scheduler re-authenticates per-user on each tick using credentials stored in
- * {@code user_data_source_config} (populated by {@link LibreLinkUpController} after a successful
- * iOS "Sync LibreLinkUp" action). The in-memory LLU token is reused if still valid.
+ * <p>On-demand refreshes from the iOS app go through the same {@link LibreLinkUpSyncService} via
+ * {@code POST /api/libre/sync-now}, so a manual refresh and a scheduler tick can never double-fetch
+ * the same user concurrently.
  */
 @Slf4j
 @Component
@@ -45,19 +38,11 @@ import java.util.concurrent.atomic.AtomicInteger;
 public class LibreLinkUpGlucoseSyncScheduler {
 
     private final UserDataSourceConfigRepository configRepository;
-    private final LibreLinkUpService libreLinkUpService;
-    private final NightscoutChartDataService nightscoutChartDataService;
-    private final UserGlucoseSyncStateService syncStateService;
-
-    @Value("${app.libre-sync.fast-interval-minutes:5}")
-    private long fastIntervalMinutes;
-
-    @Value("${app.libre-sync.slow-interval-minutes:15}")
-    private long slowIntervalMinutes;
+    private final LibreLinkUpSyncService syncService;
 
     /**
-     * BE-P1-1 fix: bounded thread pool so N users are synced in parallel (max 8 at once)
-     * instead of sequentially. Prevents tick duration from scaling linearly with user count.
+     * BE-P1-1: bounded thread pool so N users are synced in parallel (max 8 at once) instead of
+     * sequentially. Prevents tick duration from scaling linearly with user count.
      */
     private static final int MAX_CONCURRENT_SYNCS = 8;
     private final ExecutorService syncExecutor = Executors.newFixedThreadPool(
@@ -78,18 +63,6 @@ public class LibreLinkUpGlucoseSyncScheduler {
         }
     }
 
-    /** Direction string from LibreLinkUp trend int (mirrors iOS NightscoutEntry.directionArrow). */
-    private static String trendToDirection(int trend) {
-        switch (trend) {
-            case 1: return "SingleUp";
-            case 2: return "FortyFiveUp";
-            case 3: return "Flat";
-            case 4: return "FortyFiveDown";
-            case 5: return "SingleDown";
-            default: return "Flat";
-        }
-    }
-
     @Scheduled(
             initialDelayString  = "${app.libre-sync.initial-delay-ms:20000}",
             fixedDelayString    = "${app.libre-sync.fixed-delay-ms:300000}"
@@ -107,116 +80,29 @@ public class LibreLinkUpGlucoseSyncScheduler {
         }
         log.info("LibreLinkUp sync: {} user(s) with active LibreLinkUp config", userIds.size());
 
-        // BE-P1-1 fix: process users in parallel up to MAX_CONCURRENT_SYNCS at a time.
-        AtomicInteger skippedBackoff = new AtomicInteger();
-        AtomicInteger skippedNoCreds = new AtomicInteger();
         AtomicInteger newData = new AtomicInteger();
         AtomicInteger noChange = new AtomicInteger();
+        AtomicInteger skippedBackoff = new AtomicInteger();
+        AtomicInteger skippedNoCreds = new AtomicInteger();
+        AtomicInteger inProgress = new AtomicInteger();
         AtomicInteger errors = new AtomicInteger();
 
         List<CompletableFuture<Void>> futures = new ArrayList<>(userIds.size());
         for (UUID userId : userIds) {
             futures.add(CompletableFuture.runAsync(() -> {
-                try {
-                    UserGlucoseSyncState state = syncStateService.getOrCreate(userId);
-                    if (state.getNextPollAt() != null && now.isBefore(state.getNextPollAt())) {
-                        skippedBackoff.incrementAndGet();
-                        syncStateService.markSkippedBackoff(userId, now);
-                        log.debug("LibreLinkUp sync user={} skipped by backoff (nextPollAt={})",
-                                userId, state.getNextPollAt());
-                        return;
-                    }
-
-                    // Load stored LLU credentials.
-                    UserDataSourceConfig cfg = configRepository
-                            .findByUserIdAndDataSourceAndIsActiveTrue(userId, UserDataSourceConfig.DataSourceType.LIBRE_LINK_UP)
-                            .orElse(null);
-                    if (cfg == null || cfg.getLibreEmail() == null || cfg.getLibrePassword() == null
-                            || cfg.getLibrePatientId() == null || cfg.getLibrePatientId().isBlank()) {
-                        skippedNoCreds.incrementAndGet();
-                        log.warn("LibreLinkUp sync user={} skipped: missing credentials or patientId in config", userId);
-                        return;
-                    }
-
-                    // Ensure authenticated — re-authenticate if token missing (e.g. after restart).
-                    if (!libreLinkUpService.isAuthenticated(userId)) {
-                        log.info("LibreLinkUp sync user={} re-authenticating (no in-memory token)", userId);
-                        LibreAuthRequest authReq = new LibreAuthRequest();
-                        authReq.setEmail(cfg.getLibreEmail());
-                        authReq.setPassword(cfg.getLibrePassword());
-                        authReq.setLocale(cfg.getLibreLocale());
-                        libreLinkUpService.authenticate(authReq, userId);
-                    }
-
-                    // Fetch glucose readings (1 day window — sufficient for CGM chart).
-                    var glucoseData = libreLinkUpService.getGlucoseData(cfg.getLibrePatientId(), 1, userId);
-                    if (glucoseData == null || glucoseData.getData() == null || glucoseData.getData().isEmpty()) {
-                        noChange.incrementAndGet();
-                        syncStateService.markNoChange(userId, now, now.plusMinutes(slowIntervalMinutes));
-                        log.info("LibreLinkUp sync user={} no readings returned", userId);
-                        return;
-                    }
-
-                    // Convert LibreGlucoseReading → NightscoutEntryDto so we can reuse chart storage.
-                    List<NightscoutEntryDto> entries = new ArrayList<>();
-                    for (var reading : glucoseData.getData()) {
-                        if (reading.getTimestamp() == null) continue;
-                        long epochMs = reading.getTimestamp().getTime();
-                        // Convert mmol/L back to mg/dL for storage (NightscoutEntryDto uses mg/dL).
-                        int sgv = (int) Math.round(reading.getValue() * 18.0);
-                        String direction = trendToDirection(reading.getTrend());
-                        String id = "llu-" + cfg.getLibrePatientId().replace("-", "") + "-" + epochMs;
-                        NightscoutEntryDto entry = new NightscoutEntryDto(
-                                id, sgv, epochMs,
-                                Instant.ofEpochMilli(epochMs).toString(),
-                                reading.getTrend(), direction,
-                                "LibreLinkUp", "sgv", 0,
-                                Instant.ofEpochMilli(epochMs).toString()
-                        );
-                        entries.add(entry);
-                    }
-
-                    nightscoutChartDataService.storeChartData(userId, entries);
-
-                    OptionalLong newestTs = entries.stream()
-                            .mapToLong(NightscoutEntryDto::getDate)
-                            .max();
-
-                    long prevSeen = state.getLastSeenEntryTimestamp() == null ? Long.MIN_VALUE
-                            : state.getLastSeenEntryTimestamp();
-                    boolean hasNew = newestTs.isPresent() && newestTs.getAsLong() > prevSeen;
-
-                    if (hasNew) {
-                        newData.incrementAndGet();
-                        syncStateService.markNewData(userId, newestTs.getAsLong(), now,
-                                now.plusMinutes(fastIntervalMinutes));
-                        log.info("LibreLinkUp sync user={} new data (readings={}, newestTs={}, nextPoll={})",
-                                userId, entries.size(), newestTs.getAsLong(),
-                                now.plusMinutes(fastIntervalMinutes));
-                    } else {
-                        noChange.incrementAndGet();
-                        syncStateService.markNoChange(userId, now, now.plusMinutes(slowIntervalMinutes));
-                        log.info("LibreLinkUp sync user={} no new data (readings={}, nextPoll={})",
-                                userId, entries.size(), now.plusMinutes(slowIntervalMinutes));
-                    }
-
-                } catch (Exception e) {
-                    errors.incrementAndGet();
-                    // If the LLU API rejected the token (401 / "not authenticated"), evict it from the
-                    // in-memory store so the next tick re-authenticates cleanly.
-                    String msg = e.getMessage() != null ? e.getMessage() : "";
-                    if (msg.contains("401") || msg.toLowerCase().contains("unauthorized")
-                            || msg.toLowerCase().contains("not authenticated")) {
-                        libreLinkUpService.logout(userId);
-                        log.info("LibreLinkUp sync user={} — token rejected (401), evicted for re-auth on next tick", userId);
-                    }
-                    syncStateService.markError(userId, now);
-                    log.warn("LibreLinkUp sync failed for user {}: {}", userId, e.getMessage());
+                Outcome outcome = syncService.syncUser(userId, false);
+                switch (outcome) {
+                    case NEW_DATA         -> newData.incrementAndGet();
+                    case NO_CHANGE        -> noChange.incrementAndGet();
+                    case SKIPPED_BACKOFF  -> skippedBackoff.incrementAndGet();
+                    case SKIPPED_NO_CREDS -> skippedNoCreds.incrementAndGet();
+                    case IN_PROGRESS      -> inProgress.incrementAndGet();
+                    case ERROR            -> errors.incrementAndGet();
                 }
             }, syncExecutor));
         }
 
-        // Wait for all user syncs to finish (with 4-min safety timeout to stay within fixedDelay).
+        // Wait for all user syncs to finish (4-min safety timeout to stay within fixedDelay).
         try {
             CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]))
                     .get(4, TimeUnit.MINUTES);
@@ -224,7 +110,9 @@ public class LibreLinkUpGlucoseSyncScheduler {
             log.warn("LibreLinkUp sync: not all user tasks finished within timeout: {}", e.getMessage());
         }
 
-        log.info("LibreLinkUp sync summary: users={}, skippedBackoff={}, skippedNoCreds={}, newData={}, noChange={}, errors={}",
-                userIds.size(), skippedBackoff.get(), skippedNoCreds.get(), newData.get(), noChange.get(), errors.get());
+        log.info("LibreLinkUp sync summary: users={}, newData={}, noChange={}, skippedBackoff={}, "
+                        + "skippedNoCreds={}, inProgress={}, errors={}",
+                userIds.size(), newData.get(), noChange.get(), skippedBackoff.get(),
+                skippedNoCreds.get(), inProgress.get(), errors.get());
     }
 }

--- a/src/main/java/che/glucosemonitorbe/service/LibreLinkUpSyncService.java
+++ b/src/main/java/che/glucosemonitorbe/service/LibreLinkUpSyncService.java
@@ -1,0 +1,246 @@
+package che.glucosemonitorbe.service;
+
+import che.glucosemonitorbe.domain.UserDataSourceConfig;
+import che.glucosemonitorbe.domain.UserGlucoseSyncState;
+import che.glucosemonitorbe.dto.LibreAuthRequest;
+import che.glucosemonitorbe.dto.NightscoutEntryDto;
+import che.glucosemonitorbe.repository.UserDataSourceConfigRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.OptionalLong;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.ReentrantLock;
+
+/**
+ * Fetches CGM readings from LibreLinkUp for a single user and stores them in
+ * {@code nightscout_chart_data} (reusing the Nightscout chart storage so the iOS chart endpoint
+ * works for both data sources).
+ *
+ * <p>Used by two callers:
+ * <ul>
+ *   <li>{@code LibreLinkUpGlucoseSyncScheduler} — periodic background sync ({@code force = false},
+ *       respects per-user backoff).</li>
+ *   <li>{@code LibreLinkUpController#syncNow} — on-demand sync triggered by the iOS refresh button
+ *       ({@code force = true}, bypasses backoff).</li>
+ * </ul>
+ *
+ * <p><b>Concurrency.</b> Each user has a dedicated {@link ReentrantLock}, so:
+ * <ul>
+ *   <li>Different users sync fully in parallel (their LLU tokens and DB rows are independent).</li>
+ *   <li>The same user never runs two syncs at once — a second request for that user either skips
+ *       immediately (scheduler) or waits briefly (on-demand) for the in-flight sync.</li>
+ *   <li>Rapid on-demand requests are coalesced: if a forced sync completed within
+ *       {@code on-demand-min-interval-seconds}, the next forced request returns the just-synced
+ *       data instead of hitting LibreLinkUp again.</li>
+ * </ul>
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class LibreLinkUpSyncService {
+
+    public enum Outcome {
+        /** New readings were fetched and stored. */
+        NEW_DATA,
+        /** Sync ran but no newer readings than last time (or none returned). */
+        NO_CHANGE,
+        /** Periodic sync skipped because the per-user backoff window has not elapsed. */
+        SKIPPED_BACKOFF,
+        /** No usable LibreLinkUp credentials / patientId stored for the user. */
+        SKIPPED_NO_CREDS,
+        /** Another sync for this user is already running and could not be coalesced in time. */
+        IN_PROGRESS,
+        /** Sync failed (auth/network/decrypt error). */
+        ERROR
+    }
+
+    private final UserDataSourceConfigRepository configRepository;
+    private final LibreLinkUpService libreLinkUpService;
+    private final NightscoutChartDataService nightscoutChartDataService;
+    private final UserGlucoseSyncStateService syncStateService;
+
+    @Value("${app.libre-sync.fast-interval-minutes:5}")
+    private long fastIntervalMinutes;
+
+    @Value("${app.libre-sync.slow-interval-minutes:15}")
+    private long slowIntervalMinutes;
+
+    /** How long an on-demand request waits for an in-flight sync of the same user before giving up. */
+    @Value("${app.libre-sync.on-demand-wait-seconds:25}")
+    private long onDemandWaitSeconds;
+
+    /** Minimum gap between two actual LLU fetches for the same user via on-demand sync. */
+    @Value("${app.libre-sync.on-demand-min-interval-seconds:8}")
+    private long onDemandMinIntervalSeconds;
+
+    /** Per-user locks. Bounded by the number of distinct LibreLinkUp users (small). */
+    private final ConcurrentHashMap<UUID, ReentrantLock> userLocks = new ConcurrentHashMap<>();
+
+    /** Last completed forced (on-demand) sync per user, for request coalescing. */
+    private final ConcurrentHashMap<UUID, Instant> lastForcedSyncAt = new ConcurrentHashMap<>();
+
+    private ReentrantLock lockFor(UUID userId) {
+        return userLocks.computeIfAbsent(userId, k -> new ReentrantLock());
+    }
+
+    /**
+     * Sync a single user's LibreLinkUp readings into chart storage.
+     *
+     * @param userId the user to sync
+     * @param force  {@code true} for on-demand (ignore backoff, wait for any in-flight sync of the
+     *               same user); {@code false} for the scheduler (respect backoff, skip if busy)
+     * @return the {@link Outcome} of the attempt
+     */
+    public Outcome syncUser(UUID userId, boolean force) {
+        ReentrantLock lock = lockFor(userId);
+        boolean acquired;
+        try {
+            // Scheduler: tryLock(0) — skip instantly if this user is already syncing.
+            // On-demand: wait up to onDemandWaitSeconds for the in-flight sync to finish.
+            acquired = lock.tryLock(force ? onDemandWaitSeconds : 0, TimeUnit.SECONDS);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            log.warn("LibreLinkUp sync user={} interrupted while waiting for lock", userId);
+            return Outcome.ERROR;
+        }
+        if (!acquired) {
+            log.debug("LibreLinkUp sync user={} skipped: another sync in progress (force={})", userId, force);
+            return Outcome.IN_PROGRESS;
+        }
+        try {
+            // Coalesce rapid on-demand requests: if we just synced this user, the cache is already
+            // fresh — don't hit LibreLinkUp again.
+            if (force) {
+                Instant last = lastForcedSyncAt.get(userId);
+                if (last != null
+                        && Duration.between(last, Instant.now()).getSeconds() < onDemandMinIntervalSeconds) {
+                    log.debug("LibreLinkUp on-demand sync user={} coalesced (last forced sync {}s ago)",
+                            userId, Duration.between(last, Instant.now()).getSeconds());
+                    return Outcome.NO_CHANGE;
+                }
+            }
+
+            Outcome outcome = doSync(userId, force, LocalDateTime.now());
+            if (force) {
+                lastForcedSyncAt.put(userId, Instant.now());
+            }
+            return outcome;
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    /** The actual fetch+store. Always called while holding this user's lock. */
+    private Outcome doSync(UUID userId, boolean force, LocalDateTime now) {
+        try {
+            UserGlucoseSyncState state = syncStateService.getOrCreate(userId);
+
+            // Periodic syncs honour the adaptive backoff window; on-demand syncs ignore it.
+            if (!force && state.getNextPollAt() != null && now.isBefore(state.getNextPollAt())) {
+                syncStateService.markSkippedBackoff(userId, now);
+                log.debug("LibreLinkUp sync user={} skipped by backoff (nextPollAt={})",
+                        userId, state.getNextPollAt());
+                return Outcome.SKIPPED_BACKOFF;
+            }
+
+            UserDataSourceConfig cfg = configRepository
+                    .findByUserIdAndDataSourceAndIsActiveTrue(userId, UserDataSourceConfig.DataSourceType.LIBRE_LINK_UP)
+                    .orElse(null);
+            if (cfg == null || cfg.getLibreEmail() == null || cfg.getLibrePassword() == null
+                    || cfg.getLibrePatientId() == null || cfg.getLibrePatientId().isBlank()) {
+                log.warn("LibreLinkUp sync user={} skipped: missing credentials or patientId in config", userId);
+                return Outcome.SKIPPED_NO_CREDS;
+            }
+
+            // Ensure authenticated — re-authenticate if the in-memory token is missing (e.g. restart).
+            if (!libreLinkUpService.isAuthenticated(userId)) {
+                log.info("LibreLinkUp sync user={} re-authenticating (no in-memory token)", userId);
+                LibreAuthRequest authReq = new LibreAuthRequest();
+                authReq.setEmail(cfg.getLibreEmail());
+                authReq.setPassword(cfg.getLibrePassword());
+                authReq.setLocale(cfg.getLibreLocale());
+                libreLinkUpService.authenticate(authReq, userId);
+            }
+
+            var glucoseData = libreLinkUpService.getGlucoseData(cfg.getLibrePatientId(), 1, userId);
+            if (glucoseData == null || glucoseData.getData() == null || glucoseData.getData().isEmpty()) {
+                syncStateService.markNoChange(userId, now, now.plusMinutes(slowIntervalMinutes));
+                log.info("LibreLinkUp sync user={} no readings returned", userId);
+                return Outcome.NO_CHANGE;
+            }
+
+            List<NightscoutEntryDto> entries = new ArrayList<>();
+            for (var reading : glucoseData.getData()) {
+                if (reading.getTimestamp() == null) continue;
+                long epochMs = reading.getTimestamp().getTime();
+                // Convert mmol/L back to mg/dL for storage (NightscoutEntryDto uses mg/dL).
+                int sgv = (int) Math.round(reading.getValue() * 18.0);
+                String direction = trendToDirection(reading.getTrend());
+                String id = "llu-" + cfg.getLibrePatientId().replace("-", "") + "-" + epochMs;
+                NightscoutEntryDto entry = new NightscoutEntryDto(
+                        id, sgv, epochMs,
+                        Instant.ofEpochMilli(epochMs).toString(),
+                        reading.getTrend(), direction,
+                        "LibreLinkUp", "sgv", 0,
+                        Instant.ofEpochMilli(epochMs).toString()
+                );
+                entries.add(entry);
+            }
+
+            nightscoutChartDataService.storeChartData(userId, entries);
+
+            OptionalLong newestTs = entries.stream().mapToLong(NightscoutEntryDto::getDate).max();
+            long prevSeen = state.getLastSeenEntryTimestamp() == null ? Long.MIN_VALUE
+                    : state.getLastSeenEntryTimestamp();
+            boolean hasNew = newestTs.isPresent() && newestTs.getAsLong() > prevSeen;
+
+            if (hasNew) {
+                syncStateService.markNewData(userId, newestTs.getAsLong(), now,
+                        now.plusMinutes(fastIntervalMinutes));
+                log.info("LibreLinkUp sync user={} new data (readings={}, newestTs={}, force={})",
+                        userId, entries.size(), newestTs.getAsLong(), force);
+                return Outcome.NEW_DATA;
+            }
+
+            syncStateService.markNoChange(userId, now, now.plusMinutes(slowIntervalMinutes));
+            log.info("LibreLinkUp sync user={} no new data (readings={}, force={})",
+                    userId, entries.size(), force);
+            return Outcome.NO_CHANGE;
+
+        } catch (Exception e) {
+            // If the LLU API rejected the token (401 / "not authenticated"), evict it so the next
+            // sync re-authenticates cleanly.
+            String msg = e.getMessage() != null ? e.getMessage() : "";
+            if (msg.contains("401") || msg.toLowerCase().contains("unauthorized")
+                    || msg.toLowerCase().contains("not authenticated")) {
+                libreLinkUpService.logout(userId);
+                log.info("LibreLinkUp sync user={} — token rejected (401), evicted for re-auth", userId);
+            }
+            syncStateService.markError(userId, now);
+            log.warn("LibreLinkUp sync failed for user {}: {}", userId, e.getMessage());
+            return Outcome.ERROR;
+        }
+    }
+
+    /** Direction string from LibreLinkUp trend int (mirrors iOS NightscoutEntry.directionArrow). */
+    private static String trendToDirection(int trend) {
+        switch (trend) {
+            case 1:  return "SingleUp";
+            case 2:  return "FortyFiveUp";
+            case 3:  return "Flat";
+            case 4:  return "FortyFiveDown";
+            case 5:  return "SingleDown";
+            default: return "Flat";
+        }
+    }
+}


### PR DESCRIPTION
Extract per-user LibreLinkUp fetch+store into LibreLinkUpSyncService with a per-user ReentrantLock (parallel across users, serialized per user) and a force flag. Scheduler delegates to it (force=false, respects backoff); new POST /api/libre/sync-now triggers an immediate sync (force=true, bypasses backoff) so the iOS refresh button / dashboard-open does not wait for the 5-min tick. Rapid repeat requests are coalesced within a short window.